### PR TITLE
fix: set owner of /config volume

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,8 @@
 FROM docker.io/alpine:latest
 
 RUN apk add --no-cache tzdata && \
-    addgroup -g 1000 -S appuser && adduser -u 1000 -S -G appuser appuser
+    addgroup -g 1000 -S appuser && adduser -u 1000 -S -G appuser appuser && \
+    mkdir /config && chown appuser:appuser /config
 USER appuser
 
 ARG TARGETARCH


### PR DESCRIPTION
Hey, first thanks for making this project :-)

Just a little annoyance that I'm proposing to fix with this PR: when you run the Docker image with the default volume for /config or a custom named volume (but not a bind mount), it gets created as root instead of appuser (1000) and the app fails to start with "unable to open database file: out of memory (14)".

So this PR simply creates the /config directory with the right permissions in advance, so that the volume keeps these permissions and the app starts normally.